### PR TITLE
Support subdirectories download cloudfiles

### DIFF
--- a/providers/file.rb
+++ b/providers/file.rb
@@ -49,7 +49,13 @@ action :create do
   end
 
   directory = get_directory(new_resource.directory)
-  directory.files.get(::File.basename(new_resource.filename)) do |data, remaining, content_length|
+  if new_resource.filepath
+    filepath = new_resource.filepath
+  else
+    filepath = ::File.basename(new_resource.filename)
+  end
+  
+  directory.files.get(filepath) do |data, remaining, content_length|
     f.syswrite data
   end
 

--- a/resources/file.rb
+++ b/resources/file.rb
@@ -28,6 +28,7 @@ attribute :rackspace_region, :kind_of => String, :default => "dfw"
 attribute :rackspace_auth_url, :kind_of => String
 attribute :filename, :kind_of => String, :name_attribute => true
 attribute :directory, :kind_of => String, :required => true
+attribute :filepath, :kind_of => String
 attribute :binmode, :kind_of => [ TrueClass, FalseClass ], :default => false
 
 attr_accessor :exists


### PR DESCRIPTION
At the moment the rackspacecloud_file resource can only download files if they are in the root of the container. This change allows downloading files in subdirectories.  

It's backwards compatible and will not affect existing use of the resource.