### PR TITLE
support downloading cloudfiles in subdirectories

### DIFF
--- a/resources/file.rb
+++ b/resources/file.rb
@@ -22,13 +22,14 @@ actions :create, :create_if_missing, :upload
 
 default_action :create
 
-attribute :rackspace_username, :kind_of => String, :required => true
-attribute :rackspace_api_key, :kind_of => String, :required => true
-attribute :rackspace_region, :kind_of => String, :default => "dfw"
-attribute :rackspace_auth_url, :kind_of => String
-attribute :filename, :kind_of => String, :name_attribute => true
-attribute :directory, :kind_of => String, :required => true
-attribute :binmode, :kind_of => [ TrueClass, FalseClass ], :default => false
+attribute :rackspace_username, kind_of: String, required: true
+attribute :rackspace_api_key, kind_of: String, required: true
+attribute :rackspace_region, kind_of: String, default: 'dfw'
+attribute :rackspace_auth_url, kind_of: String
+attribute :filename, kind_of: String, name_attribute: true
+attribute :directory, kind_of: String, required: true
+attribute :filepath, kind_of: String
+attribute :binmode, kind_of: [TrueClass, FalseClass], default: false
 
 attr_accessor :exists
 attr_accessor :checksum


### PR DESCRIPTION
Currently the rackspacecloud_file resource only supports downloading/uploading to the root of the container.  This PR adds the ability to upload or download cloudfiles to/from a subdirectory within a container.

It is backwards compatible, so if the new filepath attribute is left blank the resource will operate in the same way it does now.
